### PR TITLE
Fix live tests picking up wrong registration's emails

### DIFF
--- a/email_automation/tests/test_email_chain.py
+++ b/email_automation/tests/test_email_chain.py
@@ -97,6 +97,7 @@ class TestEmailChainValidation:
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=registration_data.get("registration_date_gmail"),
+            recipient=registration_data.get("email"),
         )
         assert email_data is not None, (
             "Email 1 (OTP email) was not found in Gmail inbox after registration."
@@ -110,6 +111,7 @@ class TestEmailChainValidation:
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=registration_data.get("registration_date_gmail"),
+            recipient=registration_data.get("email"),
         )
         assert email_data is not None, (
             "Email 2 (Welcome email) was not found in Gmail inbox after registration."
@@ -143,6 +145,7 @@ class TestEmailChainValidation:
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=registration_data.get("registration_date_gmail"),
+            recipient=registration_data.get("email"),
         )
         assert email_data is not None, (
             f"{email_id} expected by Day {day_offset} but not found in Gmail."

--- a/email_automation/tests/test_email_content.py
+++ b/email_automation/tests/test_email_content.py
@@ -202,6 +202,7 @@ class TestBodyValidationLive:
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=registration_data.get("registration_date_gmail"),
+            recipient=registration_data.get("email"),
         )
         if email_data is None:
             pytest.fail(f"{email_id} not found in Gmail inbox.")

--- a/email_automation/tests/test_email_recipient.py
+++ b/email_automation/tests/test_email_recipient.py
@@ -108,6 +108,7 @@ class TestRecipientValidationLive:
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=registration_data.get("registration_date_gmail"),
+            recipient=registration_data.get("email"),
         )
         if email_data is None:
             pytest.fail(f"{email_id} not found in Gmail inbox.")

--- a/email_automation/tests/test_email_subject.py
+++ b/email_automation/tests/test_email_subject.py
@@ -120,6 +120,7 @@ class TestSubjectValidationLive:
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=registration_data.get("registration_date_gmail"),
+            recipient=registration_data.get("email"),
         )
         if email_data is None:
             pytest.skip("Email 1 not yet received – skipping live subject test.")
@@ -141,6 +142,7 @@ class TestSubjectValidationLive:
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=registration_data.get("registration_date_gmail"),
+            recipient=registration_data.get("email"),
         )
         if email_data is None:
             pytest.skip("Email 2 not yet received – skipping live subject test.")
@@ -171,6 +173,7 @@ class TestSubjectValidationLive:
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=registration_data.get("registration_date_gmail"),
+            recipient=registration_data.get("email"),
         )
         if email_data is None:
             pytest.fail(


### PR DESCRIPTION
All find_email_by_subject calls in live tests now pass recipient=registration_data["email"] so they only match emails sent to the tracked registration address. Without this, a newer registration in the same inbox returned more-recent matching emails, causing subject and recipient validation to fail against the wrong account.