### PR TITLE
Store email date windows in registration_data via scheduler

### DIFF
--- a/email_automation/services/scheduler.py
+++ b/email_automation/services/scheduler.py
@@ -93,17 +93,28 @@ class Scheduler:
         """
         Build the registration_data dict consumed by EmailValidator.
         Converts RegistrationRecord to the expected format.
+        Includes pre-computed (after_date, before_date) windows for every
+        email in the chain so tests can look them up without inline calculation.
         """
-        from email_automation.utils.date_helper import to_gmail_date_str
+        from email_automation.utils.date_helper import to_gmail_date_str, email_date_window
+        from email_automation.config.email_chain import EMAIL_CHAIN
         from datetime import datetime, timezone
 
         reg_time = datetime.fromisoformat(record.registration_time)
         if reg_time.tzinfo is None:
             reg_time = reg_time.replace(tzinfo=timezone.utc)
 
+        reg_date_gmail = to_gmail_date_str(reg_time)
+
+        email_date_windows = {
+            e.email_id: email_date_window(reg_date_gmail, e.day_offset)
+            for e in EMAIL_CHAIN
+        }
+
         return {
             "email": record.email,
             "first_name": record.first_name,
             "last_name": record.last_name,
-            "registration_date_gmail": to_gmail_date_str(reg_time),
+            "registration_date_gmail": reg_date_gmail,
+            "email_date_windows": email_date_windows,
         }

--- a/email_automation/tests/test_email_chain.py
+++ b/email_automation/tests/test_email_chain.py
@@ -11,7 +11,7 @@ from email_automation.config.email_chain import EMAIL_CHAIN, EMAIL_CHAIN_MAP
 from email_automation.config.constants import REGISTRATION_HISTORY_FILE
 from email_automation.services.email_service import EmailService
 from email_automation.utils.registration_tracker import RegistrationTracker
-from email_automation.utils.date_helper import days_since, email_date_window
+from email_automation.utils.date_helper import days_since
 
 
 # ── Registration history tests ────────────────────────────────────────────────
@@ -94,9 +94,7 @@ class TestEmailChainValidation:
     ):
         """Email 1 (OTP) must be findable in Gmail after registration."""
         email_def = EMAIL_CHAIN_MAP["email_1"]
-        after_date, before_date = email_date_window(
-            registration_data["registration_date_gmail"], email_def.day_offset
-        )
+        after_date, before_date = registration_data["email_date_windows"]["email_1"]
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=after_date,
@@ -112,9 +110,7 @@ class TestEmailChainValidation:
     ):
         """Email 2 (Welcome) must be findable in Gmail after registration."""
         email_def = EMAIL_CHAIN_MAP["email_2"]
-        after_date, before_date = email_date_window(
-            registration_data["registration_date_gmail"], email_def.day_offset
-        )
+        after_date, before_date = registration_data["email_date_windows"]["email_2"]
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=after_date,
@@ -150,9 +146,7 @@ class TestEmailChainValidation:
                 f"currently Day {days_since_registration}."
             )
         email_def = EMAIL_CHAIN_MAP[email_id]
-        after_date, before_date = email_date_window(
-            registration_data["registration_date_gmail"], email_def.day_offset
-        )
+        after_date, before_date = registration_data["email_date_windows"][email_id]
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=after_date,

--- a/email_automation/tests/test_email_content.py
+++ b/email_automation/tests/test_email_content.py
@@ -8,7 +8,6 @@ import pytest
 from email_automation.config.email_chain import EMAIL_CHAIN, EMAIL_CHAIN_MAP
 from email_automation.validators.body_validator import BodyValidator
 from email_automation.utils.text_normalizer import TextNormalizer
-from email_automation.utils.date_helper import email_date_window
 
 
 # ── Unit tests ────────────────────────────────────────────────────────────────
@@ -200,9 +199,7 @@ class TestBodyValidationLive:
                 f"currently Day {days_since_registration}."
             )
 
-        after_date, before_date = email_date_window(
-            registration_data["registration_date_gmail"], email_def.day_offset
-        )
+        after_date, before_date = registration_data["email_date_windows"][email_id]
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=after_date,

--- a/email_automation/tests/test_email_recipient.py
+++ b/email_automation/tests/test_email_recipient.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 from email_automation.config.email_chain import EMAIL_CHAIN_MAP
 from email_automation.utils.gmail_helper import EmailData
 from email_automation.validators.recipient_validator import RecipientValidator
-from email_automation.utils.date_helper import email_date_window
 
 
 # ── Unit tests (no live Gmail) ────────────────────────────────────────────────
@@ -106,9 +105,7 @@ class TestRecipientValidationLive:
                 f"currently Day {days_since_registration}."
             )
 
-        after_date, before_date = email_date_window(
-            registration_data["registration_date_gmail"], email_def.day_offset
-        )
+        after_date, before_date = registration_data["email_date_windows"][email_id]
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=after_date,

--- a/email_automation/tests/test_email_subject.py
+++ b/email_automation/tests/test_email_subject.py
@@ -7,7 +7,6 @@ import pytest
 from email_automation.config.email_chain import EMAIL_CHAIN_MAP
 from email_automation.validators.subject_validator import SubjectValidator
 from email_automation.utils.text_normalizer import TextNormalizer
-from email_automation.utils.date_helper import email_date_window
 
 
 # ── Unit tests for SubjectValidator (no live Gmail) ───────────────────────────
@@ -118,9 +117,7 @@ class TestSubjectValidationLive:
     ):
         """Verify Email 1 subject contains registered first name and a 6-digit OTP."""
         email_def = EMAIL_CHAIN_MAP["email_1"]
-        after_date, before_date = email_date_window(
-            registration_data["registration_date_gmail"], email_def.day_offset
-        )
+        after_date, before_date = registration_data["email_date_windows"]["email_1"]
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=after_date,
@@ -144,9 +141,7 @@ class TestSubjectValidationLive:
     ):
         """Verify Email 2 subject contains the registered first name."""
         email_def = EMAIL_CHAIN_MAP["email_2"]
-        after_date, before_date = email_date_window(
-            registration_data["registration_date_gmail"], email_def.day_offset
-        )
+        after_date, before_date = registration_data["email_date_windows"]["email_2"]
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=after_date,
@@ -179,9 +174,7 @@ class TestSubjectValidationLive:
                 f"{email_id} expected on Day {email_def.day_offset}; "
                 f"currently Day {days_since_registration}."
             )
-        after_date, before_date = email_date_window(
-            registration_data["registration_date_gmail"], email_def.day_offset
-        )
+        after_date, before_date = registration_data["email_date_windows"][email_id]
         email_data = gmail_helper.find_email_by_subject(
             subject_fragment=email_def.subject_search_fragment,
             after_date=after_date,


### PR DESCRIPTION
Pre-compute (after_date, before_date) for every email in the chain inside build_registration_data() so tests look up registration_data["email_date_windows"][email_id] instead of calling email_date_window() inline. Removes email_date_window imports from all 4 test files — date logic is now centralised in one place.